### PR TITLE
record CHANNEL_ID's log

### DIFF
--- a/slack.go
+++ b/slack.go
@@ -44,9 +44,9 @@ func (s *SlackListener) ListenAndResponse() {
 func (s *SlackListener) handleMessageEvent(ev *slack.MessageEvent) error {
 	// Only response in specific channel. Ignore else.
 	if ev.Channel != s.channelID {
-		log.Printf("%s %s", ev.Channel, ev.Msg.Text)
 		return nil
 	}
+	log.Printf("%s %s", ev.Channel, ev.Msg.Text)
 
 	// Only response mention to bot. Ignore else.
 	if !strings.HasPrefix(ev.Msg.Text, fmt.Sprintf("<@%s> ", s.botID)) {


### PR DESCRIPTION
Hi! ✋ handleMessageEvent() should record logs in channel defined CHANNEL_ID, not else ch.